### PR TITLE
long commit shas

### DIFF
--- a/.github/workflows/build-deploy-python-container.yaml
+++ b/.github/workflows/build-deploy-python-container.yaml
@@ -128,9 +128,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
+            CONTAINER_LABEL=sha-${{ github.sha }}
             pypi_username=${{ secrets.ARTIFACTORY_USERNAME }}
             pypi_password=${{ secrets.ARTIFACTORY_IDENTITY_TOKEN }}
-            commit_sha=${{ github.sha }}
 
       - name: Record Summary
         run: |

--- a/.github/workflows/build-deploy-python-container.yaml
+++ b/.github/workflows/build-deploy-python-container.yaml
@@ -112,6 +112,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name != 'pull_request' }}
             type=raw,value=${{ steps.pkg-version.outputs.VERSION }},enable=${{ github.event_name != 'pull_request' }}
             type=sha
+            type=sha,format=long
 
       - name: Build and push
         id: build-push
@@ -129,6 +130,7 @@ jobs:
           build-args: |
             pypi_username=${{ secrets.ARTIFACTORY_USERNAME }}
             pypi_password=${{ secrets.ARTIFACTORY_IDENTITY_TOKEN }}
+            commit_sha=${{ github.sha }}
 
       - name: Record Summary
         run: |


### PR DESCRIPTION
PR 1 of 2:
 - Docker containers will get tagged with their "long format sha"
 - The long format sha will be passed as a build arg so it can be converted into an env var at docker build time
 
 2nd PR coming up: changing a docker file to use the SHA