### PR TITLE
Use Default Branch for Version Bumps

### DIFF
--- a/.github/workflows/build-deploy-rust.yaml
+++ b/.github/workflows/build-deploy-rust.yaml
@@ -157,6 +157,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
       - name: Tag and Push
         run: |
           git config user.name github-actions


### PR DESCRIPTION
Do version bumping on the default branch.

This will ensure that two commits at the same time will both increment the version atomically