### PR TITLE
switch to base images for dockerhub

### DIFF
--- a/.github/workflows/build-deploy-maven-datadog.yaml
+++ b/.github/workflows/build-deploy-maven-datadog.yaml
@@ -108,7 +108,7 @@ jobs:
         id: mvn_build
         run: |
           mkdir artifacts
-          mvn -B deploy -Pdocker-deploy -Djib.from.image=p6m.jfrog.io/p6m-dev-docker/java-datadog:latest-java-datadog-19a5dbb -Djib.from.platforms=linux/amd64,linux/arm64 -Dmaven-jib-plugin.version=3.4.1
+          mvn -B deploy -Pdocker-deploy -Djib.from.image=ybor/java-datadog:latest-java-datadog-19a5dbb -Djib.from.platforms=linux/amd64,linux/arm64 -Dmaven-jib-plugin.version=3.4.1
           mvn $MAVEN_CLI_OPTS org.apache.maven.plugins:maven-help-plugin:3.1.1:evaluate -Dexpression=project.version -q -DforceStdout > artifacts/version
           echo $(basename ${GITHUB_REPOSITORY})
           cat $(basename ${GITHUB_REPOSITORY})-server/target/jib-image.digest

--- a/.github/workflows/build-deploy-maven.yaml
+++ b/.github/workflows/build-deploy-maven.yaml
@@ -109,7 +109,7 @@ jobs:
         id: mvn_build
         run: |
           mkdir artifacts
-          mvn -B deploy -Pdocker-deploy -Djib.from.image=p6m.jfrog.io/p6m-dev-docker/amazoncorretto:17-alpine3.17 -Djib.from.platforms=linux/amd64,linux/arm64 -Dmaven-jib-plugin.version=3.4.1
+          mvn -B deploy -Pdocker-deploy -Djib.from.image=ybor/amazoncorretto:17-alpine3.17 -Djib.from.platforms=linux/amd64,linux/arm64 -Dmaven-jib-plugin.version=3.4.1
           mvn $MAVEN_CLI_OPTS org.apache.maven.plugins:maven-help-plugin:3.1.1:evaluate -Dexpression=project.version -q -DforceStdout > artifacts/version
           echo $(basename ${GITHUB_REPOSITORY})
           cat $(basename ${GITHUB_REPOSITORY})-server/target/jib-image.digest

--- a/.github/workflows/cut-tag-maven-service.yml
+++ b/.github/workflows/cut-tag-maven-service.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Maven Build - Tag
         id: mvn_build
         run: |
-          mvn -B deploy -Pdocker-deploy -Djib.from.image=p6m.jfrog.io/p6m-dev-docker/amazoncorretto:17-alpine3.17 -Djib.from.platforms=linux/amd64,linux/arm64 -Dmaven-jib-plugin.version=3.4.1
+          mvn -B deploy -Pdocker-deploy -Djib.from.image=ybor/amazoncorretto:17-alpine3.17 -Djib.from.platforms=linux/amd64,linux/arm64 -Dmaven-jib-plugin.version=3.4.1
           cat $(basename ${GITHUB_REPOSITORY})-server/target/jib-image.digest
           echo "digest=$(cat $(basename ${GITHUB_REPOSITORY})-server/target/jib-image.digest)" >> $GITHUB_OUTPUT
 
@@ -129,7 +129,7 @@ jobs:
       - name: Maven Build - Snapshot
         id: mvn_build_snapshot
         run: |
-          mvn -B deploy -Pdocker-deploy -Djib.from.image=p6m.jfrog.io/p6m-dev-docker/p6m/amazoncorretto:17-alpine3.17 -Djib.from.platforms=linux/amd64,linux/arm64 -Dmaven-jib-plugin.version=3.4.1
+          mvn -B deploy -Pdocker-deploy -Djib.from.image=ybor/amazoncorretto:17-alpine3.17 -Djib.from.platforms=linux/amd64,linux/arm64 -Dmaven-jib-plugin.version=3.4.1
           cat $(basename ${GITHUB_REPOSITORY})-server/target/jib-image.digest
           echo "digest=$(cat $(basename ${GITHUB_REPOSITORY})-server/target/jib-image.digest)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
These containers come from 
 - https://github.com/p6m-dev/base-containers

They also push publicly to DockerHub. Let's just use dockerhub.