### PR TITLE
Cleanup extra/unused code from build-deploy-rust-service.yaml

### DIFF
--- a/.github/workflows/build-deploy-rust-service.yaml
+++ b/.github/workflows/build-deploy-rust-service.yaml
@@ -88,15 +88,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
-      - name: Install cargo-release
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: cargo-release
-          version: 0.25.10
-
       - name: Cargo build Release
-        env:
-          CARGO_INCREMENTAL: "1"
         run: |
           if [ "${{ inputs.MODE }}" = "release" ]; then
             cross build --release --target=${{ matrix.target }}


### PR DESCRIPTION
- Disabled `CARGO_INCREMENTAL`. The build artifacts used for incremental builds are automatically cleared before caching by `Swatinem/rust-cache` as enabling incremental caching on workspace targets provides no benefit in CI. It only increases the size of the uploaded artifacts unnecessarily.
- Remove `cargo-release` installation from `build` job as the `cargo release` subcommands are not used in that job.