### PR TITLE
add CROSS_BUILD_OPTS

### DIFF
--- a/.github/workflows/build-deploy-rust.yaml
+++ b/.github/workflows/build-deploy-rust.yaml
@@ -101,6 +101,10 @@ jobs:
           else
             cross build --target=${{ matrix.target }} -vv
           fi
+        env:
+          CROSS_BUILD_OPTS: |
+            --cache-from=type=gha
+            --cache-to=type=gha,mode=max
 
       - name: Get Package Version
         id: pkg-version


### PR DESCRIPTION
Ref: https://github.com/cross-rs/cross/blob/main/docs/environment_variables.md

This will theoretically add `--cache-from` and `--cache-to` to `docker buildx build` command that Cross kicks off