### PR TITLE
refactor!(build-deploy-docker): Use x86_64 runner for arm builds by default

### DIFF
--- a/.github/workflows/build-deploy-docker.yaml
+++ b/.github/workflows/build-deploy-docker.yaml
@@ -60,7 +60,7 @@ on:
         description: The `runs-on` tag for the linux arm64 runner. Defaults to the Github standard runner.
         type: string
         required: false
-        default: ubuntu-24.04-arm
+        default: ubuntu-latest
       push:
         description: Whether to push the built images to the registry. Set to false to only refresh cache.
         type: boolean
@@ -88,8 +88,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.github_ref }}
+            ref: ${{ inputs.github_ref }}
 
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/build-deploy-docker.yaml
+++ b/.github/workflows/build-deploy-docker.yaml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-            ref: ${{ inputs.github_ref }}
+          ref: ${{ inputs.github_ref }}
 
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Default to `ubuntu-latest` runner even for `linux/arm64` builds. This will always just work but might not be as fast as native runners. You can still leverage native runners by setting one of the following when calling the workflow:
```yaml
jobs:
  docker-build:
    uses: p6m-dev/github-actions/.github/workflows/build-deploy-docker.yaml@main
    with:
      linux-arm-runner: MY_PROVISIONED_ARM_RUNNER
      # OR for a public repository
      # linux-arm-runner: ubuntu-24.04-arm
      # Other inputs elided
```