### PR TITLE
fix(test-publish-rust-crates): use p6m-release-action for tag and commit

### DIFF
--- a/.github/workflows/test-publish-rust-crates.yaml
+++ b/.github/workflows/test-publish-rust-crates.yaml
@@ -22,8 +22,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_RELEASE_VERSION: 0.25.10
-  COMMIT_USER: github-actions
-  COMMIT_EMAIL: github-actions@users.noreply.github.com
 
 jobs:
   prep:
@@ -93,16 +91,13 @@ jobs:
 
       - name: Prepare next Cargo beta
         run: |
-          git config user.name ${{ env.COMMIT_USER }}
-          git config user.email ${{ env.COMMIT_EMAIL }}
-          cargo release tag --no-confirm --execute
+          echo "CURRENT_VERSION=$(cargo metadata --format-version=1 | jq -r '.workspace_members[0]' | awk -F# '{print $NF}')" >> $GITHUB_ENV
           cargo release version --no-confirm --execute beta
-          cargo release commit --no-confirm --execute
 
-      - name: Push
-        run: |
-          git push
-          git push --tags
+      - name: Tag then Commit
+        uses: p6m-actions/p6m-release-action@v2
+        with:
+          tags: v${{ env.CURRENT_VERSION }}
 
   publish-crates:
     if: ${{ inputs.publish }}


### PR DESCRIPTION
## Summary

- Replace manual `git config`, `cargo release tag`, `cargo release commit`, and `git push` steps with `p6m-release-action@v2`
- Capture current version before bumping to beta so the correct tag is applied to the release
- Add missing `v` prefix to the tag to match conventions used across other workflows

## Test plan

- [ ] Trigger `bump-version` job and verify the correct release tag (e.g. `v1.2.3`) is created on the pre-bump commit
- [ ] Verify the beta version bump is committed and pushed by `p6m-release-action`

**Tooling**

| Skills Used | Agents Used |
|-------------|-------------|
| `ybor-standards:git` | Claude Sonnet 4.6 |
