### PR TITLE
feat: configure sccache to use GHA cache

### DIFF
--- a/.github/workflows/build-deploy-docker.yaml
+++ b/.github/workflows/build-deploy-docker.yaml
@@ -123,9 +123,10 @@ jobs:
             ${{ inputs.build-args }}
             SCCACHE_GHA_ENABLED=on
             ACTIONS_RESULTS_URL=${{ env.ACTIONS_RESULTS_URL }}
-            ACTIONS_RUNTIME_TOKEN=${{ env.ACTIONS_RUNTIME_TOKEN }}
           secrets: ${{ secrets.secrets }}
-          secret-envs: ${{ secrets.secret-envs }}
+          secret-envs: |
+            ${{ secrets.secret-envs }}
+            ACTIONS_RUNTIME_TOKEN=ACTIONS_RUNTIME_TOKEN
           secret-files: ${{ secrets.secret-files }}
           outputs: |
             type=image,name=${{ env.DOCKER_REGISTRY }}/${{ inputs.image-name }},push=${{ inputs.push }},push-by-digest=true,name-canonical=true

--- a/.github/workflows/build-deploy-docker.yaml
+++ b/.github/workflows/build-deploy-docker.yaml
@@ -103,6 +103,13 @@ jobs:
           username: ${{ secrets.username }}
           password: ${{ secrets.password }}
 
+      - name: Configure sccache
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
@@ -111,8 +118,12 @@ jobs:
           file: ${{ inputs.dockerfile }}
           platforms: ${{ matrix.platform }}
           cache-from: type=gha,scope=${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
-          build-args: ${{ inputs.build-args }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.arch }}
+          build-args: |
+            ${{ inputs.build-args }}
+            SCCACHE_GHA_ENABLED=on
+            ACTIONS_RESULTS_URL=${{ env.ACTIONS_RESULTS_URL }}
+            ACTIONS_RUNTIME_TOKEN=${{ env.ACTIONS_RUNTIME_TOKEN }}
           secrets: ${{ secrets.secrets }}
           secret-envs: ${{ secrets.secret-envs }}
           secret-files: ${{ secrets.secret-files }}


### PR DESCRIPTION
## Summary

- Adds a `Configure sccache` step to export `ACTIONS_RESULTS_URL` and `ACTIONS_RUNTIME_TOKEN` into the environment via `actions/github-script`
- Injects `SCCACHE_GHA_ENABLED=on`, `ACTIONS_RESULTS_URL`, and `ACTIONS_RUNTIME_TOKEN` as build args so sccache uses the GHA cache backend
- Switches `cache-to` from `mode=max` to `mode=min` to avoid double-caching compiled Rust artifacts (sccache caches individual crates; layer snapshots of the builder stage would duplicate that storage against the 10GB GHA cache limit)

## Test plan

- [ ] Verify Docker build succeeds in a repo using this workflow
- [ ] Confirm sccache hits GHA cache (check sccache stats in build output)
- [ ] Confirm GHA cache usage is within limits after several runs

**Tooling**

| Skills Used | Agents Used |
|-------------|-------------|
| `ybor-standards:git` | Claude Sonnet 4.6 |
