### PR TITLE
feat: add token-exchange to workflows with git commit/push operations

### DIFF
--- a/.github/workflows/build-deploy-dotnet-service.yaml
+++ b/.github/workflows/build-deploy-dotnet-service.yaml
@@ -67,6 +67,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: p6m-actions/token-exchange@v2
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -146,8 +148,6 @@ jobs:
       - name: Commit & Tag Version
         if: github.ref_name == 'main'
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           git tag -a ${{ steps.TAG.outputs.tag_name }} -m "Release ${{ steps.TAG.outputs.value }}"
           git push origin ${{ steps.TAG.outputs.tag_name }}
 
@@ -182,8 +182,6 @@ jobs:
           xmlstarlet ed --inplace -u "//VersionPrefix" -v "${NEW_VERSION}" Directory.Build.props
           cat Directory.Build.props  # Print to verify the update
 
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           git add .
           git commit -am "[skip ci] Bump version ${NEW_VERSION}"
           git push origin main

--- a/.github/workflows/build-deploy-rust.yaml
+++ b/.github/workflows/build-deploy-rust.yaml
@@ -171,10 +171,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: p6m-actions/token-exchange@v2
+
       - name: Tag and Push
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           git tag -a ${{ needs.build.outputs.VERSION }} -m "Release ${{ needs.build.outputs.VERSION }}"
           git push origin ${{ needs.build.outputs.VERSION }}
 
@@ -194,8 +195,6 @@ jobs:
 
       - name: Commit and Push
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           git add .
           git commit -m "[skip ci] Bump Version"
           git push

--- a/.github/workflows/cut-tag-docker.yml
+++ b/.github/workflows/cut-tag-docker.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: p6m-actions/token-exchange@v2
+
       # Required for Multi-arch builds
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -77,8 +79,6 @@ jobs:
 
       - name: Git Commit & Tag
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           git add .
           git commit --allow-empty -am "Set version to ${{ steps.TAG.outputs.tag_name }}"
           git tag -a ${{ steps.TAG.outputs.tag_name }} -m "Release ${{ steps.TAG.outputs.value }}"

--- a/.github/workflows/cut-tag-dotnet-service.yaml
+++ b/.github/workflows/cut-tag-dotnet-service.yaml
@@ -72,6 +72,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - uses: p6m-actions/token-exchange@v2
+
       # Required for Multi-arch builds
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -116,8 +118,6 @@ jobs:
 
       - name: Commit & Tag Version
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           git tag -a ${{ steps.TAG.outputs.tag_name }} -m "Release ${{ steps.TAG.outputs.value }}"
           git push origin ${{ steps.TAG.outputs.tag_name }}
 
@@ -185,8 +185,6 @@ jobs:
           xmlstarlet ed --inplace -u "//VersionPrefix" -v "${NEW_VERSION}" Directory.Build.props
           cat Directory.Build.props  # Print to verify the update
 
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           git add .
           git commit -am "[skip ci] Bump version ${NEW_VERSION}"
           git push origin main

--- a/.github/workflows/cut-tag-javascript.yml
+++ b/.github/workflows/cut-tag-javascript.yml
@@ -31,6 +31,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   NX_APP: ${{ inputs.NX_APP }}
@@ -57,6 +58,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - uses: p6m-actions/token-exchange@v2
 
       - name: Login to Artifactory Container Registry
         uses: docker/login-action@v2
@@ -105,8 +108,6 @@ jobs:
       - name: Push changes
         run: |
           git fetch
-          git config user.email github-actions
-          git config user.name github-actions@github.com
           git add --all
           git commit -m "Release version ${{ steps.TAG.outputs.code_version }}"
           git push

--- a/.github/workflows/cut-tag-maven-library.yml
+++ b/.github/workflows/cut-tag-maven-library.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - uses: p6m-actions/token-exchange@v2
+
       - name: Configure Maven
         uses: whelk-io/maven-settings-xml-action@v21
         with:
@@ -87,8 +89,6 @@ jobs:
 
       - name: Git Commit & Tag
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           git add .
           git commit -am "Set version to ${{ steps.TAG.outputs.tag_name }}"
           git tag -a ${{ steps.TAG.outputs.tag_name }} -m "Release ${{ steps.TAG.outputs.value }}"
@@ -110,8 +110,6 @@ jobs:
 
       - name: Commit snapshot version update
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           git add .
           git commit -am "Prepare next development version ${{ steps.SNAPSHOT.outputs.value }}"
           git push origin ${{ github.ref_name }}

--- a/.github/workflows/cut-tag-maven-service.yml
+++ b/.github/workflows/cut-tag-maven-service.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - uses: p6m-actions/token-exchange@v2
+
       - name: Configure Maven
         uses: whelk-io/maven-settings-xml-action@v21
         with:
@@ -106,8 +108,6 @@ jobs:
 
       - name: Commit & Tag Version
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           git add .
           git commit -am "Prepare release ${{ steps.TAG.outputs.tag_name }}"
           git tag -a ${{ steps.TAG.outputs.tag_name }} -m "Release ${{ steps.TAG.outputs.value }}"
@@ -140,8 +140,6 @@ jobs:
 
       - name: Commit snapshot version update
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           git add .
           git commit -am "Prepare next development version ${{ steps.SNAPSHOT.outputs.value }}"
           git push origin main

--- a/.github/workflows/cut-tag-rust-crates.yaml
+++ b/.github/workflows/cut-tag-rust-crates.yaml
@@ -26,9 +26,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_RELEASE_VERSION: 0.25.10
-  COMMIT_USER: github-actions
-  COMMIT_EMAIL: github-actions@users.noreply.github.com 
-
 jobs:
   prep:
     runs-on: ubuntu-latest
@@ -66,6 +63,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: p6m-actions/token-exchange@v2
+
       - name: Install cargo-release
         uses: baptiste0928/cargo-install@v3
         with:
@@ -74,8 +73,6 @@ jobs:
 
       - name: Update metadata for current release
         run: |
-          git config user.name ${{ env.COMMIT_USER }}
-          git config user.email ${{ env.COMMIT_EMAIL }}
           cargo release version $EXTRA_CARGO_OPTS --no-confirm --execute ${{ inputs.level }}
           cargo release commit --no-confirm --execute
           cargo release tag $EXTRA_CARGO_OPTS --no-confirm --execute

--- a/.github/workflows/cut-tag-rust-service.yaml
+++ b/.github/workflows/cut-tag-rust-service.yaml
@@ -73,6 +73,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: p6m-actions/token-exchange@v2
+
       # Required for Multi-arch builds
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -102,8 +104,6 @@ jobs:
       - name: Commit & Tag Version
         id: tag
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           cargo release ${{ inputs.LEVEL }} --workspace --no-publish --no-push --tag-prefix '' --no-confirm --execute
 
           # The cargo release command performs a commit for us but with a generic message.
@@ -222,6 +222,8 @@ jobs:
         with:
           ref: ${{ needs.tag.outputs.name }}
 
+      - uses: p6m-actions/token-exchange@v2
+
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
@@ -235,8 +237,6 @@ jobs:
 
       - name: Prepare next beta version
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           cargo release beta --no-publish --no-push --no-tag --workspace --no-confirm -v --execute
 
           # The cargo release beta command performs a commit for us but with a generic message.

--- a/.github/workflows/test-publish-rust-crates.yaml
+++ b/.github/workflows/test-publish-rust-crates.yaml
@@ -22,9 +22,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_RELEASE_VERSION: 0.25.10
-  COMMIT_USER: github-actions
-  COMMIT_EMAIL: github-actions@users.noreply.github.com
-
 jobs:
   prep:
     runs-on: ubuntu-latest
@@ -85,6 +82,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: p6m-actions/token-exchange@v2
+
       - name: Install cargo-release
         uses: baptiste0928/cargo-install@v3
         with:
@@ -93,8 +92,6 @@ jobs:
 
       - name: Prepare next Cargo beta
         run: |
-          git config user.name ${{ env.COMMIT_USER }}
-          git config user.email ${{ env.COMMIT_EMAIL }}
           cargo release tag --no-confirm --execute
           cargo release version --no-confirm --execute beta
           cargo release commit --no-confirm --execute

--- a/.github/workflows/update-workflow-kustomize.yaml
+++ b/.github/workflows/update-workflow-kustomize.yaml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -30,7 +29,6 @@ jobs:
         with:
           ref: "main"
 
-      - uses: p6m-actions/token-exchange@v2
 
       - name: Update image digest for Run Studio Managed Clusters (via HTTPS Auth)
         run: |
@@ -55,6 +53,8 @@ jobs:
         timeout-minutes: 1
         run: |
           git config --global alias.pushrebase '!git pull --rebase && git push'
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
           git commit -m "[skip ci] Update ${{ github.event.client_payload.directory_name }} image digest to ${{ github.event.client_payload.digest }}"
           until git pushrebase origin main; do
             echo "Push/Rebase failed, retrying..."

--- a/.github/workflows/update-workflow-kustomize.yaml
+++ b/.github/workflows/update-workflow-kustomize.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -29,6 +30,7 @@ jobs:
         with:
           ref: "main"
 
+      - uses: p6m-actions/token-exchange@v2
 
       - name: Update image digest for Run Studio Managed Clusters (via HTTPS Auth)
         run: |
@@ -53,8 +55,6 @@ jobs:
         timeout-minutes: 1
         run: |
           git config --global alias.pushrebase '!git pull --rebase && git push'
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
           git commit -m "[skip ci] Update ${{ github.event.client_payload.directory_name }} image digest to ${{ github.event.client_payload.digest }}"
           until git pushrebase origin main; do
             echo "Push/Rebase failed, retrying..."


### PR DESCRIPTION
## Summary

- Add `p6m-actions/token-exchange@v2` after checkout in 11 workflows that perform git commits/pushes
- Remove manual `git config user.name/email` — token-exchange handles identity, auth, and verified bot commit signatures
- Remove unused `COMMIT_USER` / `COMMIT_EMAIL` env vars from rust crate workflows
- Add `id-token: write` permission where needed (`cut-tag-javascript`, `update-workflow-kustomize`)

### Workflows updated
- `build-deploy-dotnet-service.yaml`
- `build-deploy-rust.yaml`
- `cut-tag-docker.yml`
- `cut-tag-dotnet-service.yaml`
- `cut-tag-javascript.yml`
- `cut-tag-maven-library.yml`
- `cut-tag-maven-service.yml`
- `cut-tag-rust-crates.yaml`
- `cut-tag-rust-service.yaml`
- `test-publish-rust-crates.yaml`
- `update-workflow-kustomize.yaml`

### Intentionally excluded
Workflows using `REPOSITORY_PUSH_TOKEN` or `SUBGRAPH_PULL_TOKEN` (PAT-based cross-repo auth):
- `build-deploy-federated-gateway.yaml`
- `generate-subgraph-domain-gateway.yaml`
- `generate-rust-subgraph-domain-gateway.yaml`

## Test plan

- [ ] Verify calling workflows pass `id-token: write` permission
- [ ] Trigger a workflow from each category (dotnet, rust, maven, javascript, kustomize) and verify commits are signed by `p6m-ybor[bot]`
- [ ] Verify git push operations succeed with the exchanged token

**Tooling**

| Skills Used | Agents Used |
|-------------|-------------|
| `ybor-standards:git` | Claude Opus 4.6 |
