### PR TITLE
ci(build-deploy-docker): upgrade actions off Node 20, default arm to ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/build-deploy-docker.yaml
+++ b/.github/workflows/build-deploy-docker.yaml
@@ -57,10 +57,10 @@ on:
         default: ""
         required: true
       linux-arm-runner:
-        description: The `runs-on` tag for the linux arm64 runner. Defaults to the Github standard runner.
+        description: The `runs-on` tag for the linux arm64 runner. Defaults to the GitHub-hosted arm64 runner (ubuntu-24.04-arm), which builds arm64 natively instead of under QEMU emulation.
         type: string
         required: false
-        default: ubuntu-latest
+        default: ubuntu-24.04-arm
       push:
         description: Whether to push the built images to the registry. Set to false to only refresh cache.
         type: boolean
@@ -86,25 +86,25 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.github_ref }}
 
       - name: Docker Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Repo
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ secrets.username }}
           password: ${{ secrets.password }}
 
       - name: Configure sccache
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
@@ -112,7 +112,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -136,7 +136,7 @@ jobs:
           echo "${{ steps.build.outputs.digest }}" > ${RUNNER_TEMP}/digests/digest-${{ matrix.arch }}.txt
 
       - name: Upload Image Digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
@@ -155,14 +155,14 @@ jobs:
 
     steps:
       - name: Download Image Digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Login to Docker Repo
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ secrets.username }}
@@ -170,7 +170,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ env.DOCKER_REGISTRY }}/${{ inputs.image-name }}


### PR DESCRIPTION
## Summary

GitHub is deprecating the Node 20 actions runtime (Node 24 forced on **2026-06-02**; Node 20 removed from runners 2026-09-16). Every action in `build-deploy-docker.yaml` currently runs on Node 20 and emits a deprecation warning on every consumer's build. This bumps each to its latest **Node 24** major and, while here, defaults the arm64 leg to a native runner.

### Default arm runner

### Background 
The change away from the arm runner was done because the runner image was not available for publicly available (https://github.com/p6m-dev/github-actions/pull/28) that was changed Aug 2025 ([related blog post](https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/))

### Change

`linux-arm-runner` default changed `ubuntu-latest` → **`ubuntu-24.04-arm`** so the arm64 matrix leg builds **natively** instead of under QEMU emulation.

> ⚠️ **Behavior change for all consumers**: any caller that does *not* override `linux-arm-runner` now lands on the GitHub-hosted `ubuntu-24.04-arm` runner (billed as a larger runner on private repos) instead of emulating arm64 on `ubuntu-latest`. In exchange the arm64 build drops from **~4m16s (QEMU) → ~45s (native)**, observed on the canary below.


### Action upgrades (all latest, all `runs.using: node24`)

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | **v6** |
| `docker/setup-qemu-action` | v3 | **v4** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/login-action` (×2) | v3 | **v4** |
| `actions/github-script` | v7 | **v9** |
| `docker/build-push-action` | v6 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `docker/metadata-action` | v4 | **v6** |

## Compatibility notes

- **`upload-artifact` v4→v7 and `download-artifact` v4→v8** are major jumps, but the inputs used here (`name`, `path`, `if-no-files-found`, `retention-days`, `pattern`, `merge-multiple`) are stable across those majors, and upload-v7/download-v8 share the same v4+ artifact backend, so the within-run digest hand-off stays compatible.
- **`build-push-action` v7 / `metadata-action` v6**: the `secret-envs`/`outputs` inputs and the `DOCKER_METADATA_OUTPUT_TAGS` env var (consumed by the imagetools + summary steps) are unchanged.
- **`github-script` v9**: the `core.exportVariable` API used by the sccache step is unchanged.

## Test plan

Validated end-to-end against a real consumer — [`ybor-herde/dummy-app` PR #2](https://github.com/ybor-herde/dummy-app/pull/2) temporarily pinned its `uses:` at this branch:

- ✅ All jobs green: `version`, `build (linux/amd64)`, `build (linux/arm64)`, `Create and Push Docker Manifest Lists`
- ✅ **0 Node.js 20 annotations** (previously one on nearly every job)
- ✅ Multi-arch manifest built + pushed successfully — none of the major-version jumps broke the digest hand-off or the imagetools merge
- ✅ arm64 build ran natively (~45s)

The canary will be reverted to `@main` and closed once this merges.

## Notes

No Jira ticket.

**Tooling**

| Skills Used | Agents Used |
|-------------|-------------|
| `ybor-standards:git-branch-start` | `Explore` |
| `ybor-standards:git-pr-create` | `Claude Opus 4.8` |
| `ybor-standards:cli-explorer` | |
