### PR TITLE
fix(test-front-end): pnpm credential update

### DIFF
--- a/.github/workflows/test-front-end.yaml
+++ b/.github/workflows/test-front-end.yaml
@@ -44,7 +44,9 @@ jobs:
           node-version: 18
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: |
+          npm install -g pnpm
+          echo "PNPM Version: $(pnpm --version)" >> $GITHUB_STEP_SUMMARY
 
       - name: Get pnpm cache directory path
         id: pnpm-cache-dir-path

--- a/.github/workflows/test-front-end.yaml
+++ b/.github/workflows/test-front-end.yaml
@@ -66,6 +66,7 @@ jobs:
       - name: Install dependencies
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
         run: |
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/p6m-dev-npm/:_auth' "$ARTIFACTORY_TOKEN"
           pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/${{ github.repository_owner }}-npm/:_auth' "$ARTIFACTORY_TOKEN"
           pnpm install
 

--- a/.github/workflows/test-front-end.yaml
+++ b/.github/workflows/test-front-end.yaml
@@ -63,7 +63,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install
+        run: |
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/${{ github.repository_owner }}-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm install
 
       - name: Fetch main
         run: git fetch origin main


### PR DESCRIPTION
pnpm v11.5.3+ no longer expands environment variables in project-level `.npmrc` for auth settings (security fix GHSA-3qhv-2rgh-x77r). Our CI was relying on `.npmrc` env var expansion for Artifactory auth, which
silently broke after the pnpm upgrade.

**Fix**: moved auth config out of `.npmrc` and into explicit `pnpm config set` calls before `pnpm install`. This writes tokens to the user-level config (not the repo), which pnpm still respects.

```bash
pnpm config set '//<ARTIFACTORY_HOSTNAME>/artifactory/api/npm/p6m-dev-npm/:_auth' "$ARTIFACTORY_TOKEN"
pnpm config set '//<ARTIFACTORY_HOSTNAME>/artifactory/api/npm/<ORG>-npm/:_auth' "$ARTIFACTORY_TOKEN"
pnpm install
```

Also added pnpm version logging to the step summary for easier debugging going forward.

Ref: https://pnpm.io/npmrc#environment-variables-in-auth-settings
<img width="1836" height="1502" alt="Screenshot 2026-06-16 at 8 57 16 AM" src="https://github.com/user-attachments/assets/362fc6ca-2d8e-42c1-adf2-f4f1a804b154" />
Ref: https://github.com/ybor-playground/front-end-apps/actions/runs/27620058057/job/81667028861
`Install dependencies` succeeded despite the warnings about the project-level `.npmrc`