### PR TITLE
fix(test-front-end): pnpm credential update

### DIFF
--- a/.github/workflows/build-deploy-front-end-container.yaml
+++ b/.github/workflows/build-deploy-front-end-container.yaml
@@ -75,7 +75,9 @@ jobs:
           node-version: 18
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: |
+          npm install -g pnpm
+          echo "PNPM Version: $(pnpm --version)" >> $GITHUB_STEP_SUMMARY
 
       - name: Get pnpm cache directory path
         id: pnpm-cache-dir-path
@@ -94,12 +96,15 @@ jobs:
 
       - name: Install dependencies
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install
+        run: |
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/p6m-dev-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/${{ github.repository_owner }}-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm install
 
       - name: Test
         run: |
           pnpm nx run-many --target=lint --all --parallel=5
-      
+
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-deploy-front-end-docs.yaml
+++ b/.github/workflows/build-deploy-front-end-docs.yaml
@@ -41,7 +41,9 @@ jobs:
           node-version: 16
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: |
+          npm install -g pnpm
+          echo "PNPM Version: $(pnpm --version)" >> $GITHUB_STEP_SUMMARY
 
       - name: Get pnpm cache directory path
         id: pnpm-cache-dir-path
@@ -60,7 +62,10 @@ jobs:
 
       - name: Install dependencies
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install
+        run: |
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/p6m-dev-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/${{ github.repository_owner }}-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm install
 
       - name: Build Docs
         run: pnpm nx build docs
@@ -81,7 +86,7 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           # Upload entire repository
-          path: './ready'
+          path: "./ready"
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/build-deploy-front-end-static.yaml
+++ b/.github/workflows/build-deploy-front-end-static.yaml
@@ -51,7 +51,9 @@ jobs:
           node-version: 16
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: |
+          npm install -g pnpm
+          echo "PNPM Version: $(pnpm --version)" >> $GITHUB_STEP_SUMMARY
 
       - name: Get pnpm cache directory path
         id: pnpm-cache-dir-path
@@ -70,7 +72,10 @@ jobs:
 
       - name: Install dependencies
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install
+        run: |
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/p6m-dev-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/${{ github.repository_owner }}-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm install
 
       - name: Test
         run: |

--- a/.github/workflows/build-deploy-nextjs-app.yaml
+++ b/.github/workflows/build-deploy-nextjs-app.yaml
@@ -75,7 +75,9 @@ jobs:
           node-version: 18
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: |
+          npm install -g pnpm
+          echo "PNPM Version: $(pnpm --version)" >> $GITHUB_STEP_SUMMARY
 
       - name: Get pnpm cache directory path
         id: pnpm-cache-dir-path
@@ -94,7 +96,10 @@ jobs:
 
       - name: Install dependencies
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install
+        run: |
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/p6m-dev-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/${{ github.repository_owner }}-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm install
 
       - name: Test
         run: |

--- a/.github/workflows/cut-tag-javascript.yml
+++ b/.github/workflows/cut-tag-javascript.yml
@@ -71,7 +71,9 @@ jobs:
           node-version: 18
       
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: |
+          npm install -g pnpm
+          echo "PNPM Version: $(pnpm --version)" >> $GITHUB_STEP_SUMMARY
 
       - name: Get pnpm cache directory path
         id: pnpm-cache-dir-path
@@ -90,7 +92,10 @@ jobs:
 
       - name: Install dependencies
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install
+        run: |
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/p6m-dev-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/${{ github.repository_owner }}-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm install
       
       - name: Get Tag Version
         id: TAG

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -81,7 +81,9 @@ jobs:
           node-version: 16
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: |
+          npm install -g pnpm
+          echo "PNPM Version: $(pnpm --version)" >> $GITHUB_STEP_SUMMARY
 
       - name: Get pnpm cache directory path
         id: pnpm-cache-dir-path
@@ -108,7 +110,10 @@ jobs:
 
       - name: Install dependencies
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install
+        run: |
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/p6m-dev-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/${{ github.repository_owner }}-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm install
 
       - name: E2E Tests DEV local
         if: ${{ env.ENV == 'local_dev' && env.SPECS ==''}}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -117,7 +117,9 @@ jobs:
           node-version: 16
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: |
+          npm install -g pnpm
+          echo "PNPM Version: $(pnpm --version)" >> $GITHUB_STEP_SUMMARY
 
       - name: Get pnpm cache directory path
         id: pnpm-cache-dir-path
@@ -144,7 +146,10 @@ jobs:
 
       - name: Install dependencies
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install
+        run: |
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/p6m-dev-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/${{ github.repository_owner }}-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm install
 
       - name: E2E Smoke Tests ${{ inputs.environment }}
         if: ${{ inputs.environment == 'prod' }}
@@ -194,7 +199,9 @@ jobs:
           node-version: 16
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: |
+          npm install -g pnpm
+          echo "PNPM Version: $(pnpm --version)" >> $GITHUB_STEP_SUMMARY
 
       - name: Get pnpm cache directory path
         id: pnpm-cache-dir-path
@@ -213,7 +220,10 @@ jobs:
 
       - name: Install dependencies
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install
+        run: |
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/p6m-dev-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/${{ github.repository_owner }}-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm install
 
       - name: Download code coverage results
         if: always()
@@ -294,7 +304,9 @@ jobs:
           node-version: 16
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: |
+          npm install -g pnpm
+          echo "PNPM Version: $(pnpm --version)" >> $GITHUB_STEP_SUMMARY
 
       - name: Get pnpm cache directory path
         id: pnpm-cache-dir-path
@@ -313,7 +325,10 @@ jobs:
 
       - name: Install dependencies
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install
+        run: |
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/p6m-dev-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm config set '//${{ vars.ARTIFACTORY_HOSTNAME }}/artifactory/api/npm/${{ github.repository_owner }}-npm/:_auth' "$ARTIFACTORY_TOKEN"
+          pnpm install
 
       - name: "BrowserStack Env Setup"
         uses: "browserstack/github-actions/setup-env@master"


### PR DESCRIPTION
pnpm v11.5.3+ no longer expands environment variables in project-level `.npmrc` for auth settings (security fix GHSA-3qhv-2rgh-x77r). Our CI was relying on `.npmrc` env var expansion for Artifactory auth, which
silently broke after the pnpm upgrade.

**Fix**: moved auth config out of `.npmrc` and into explicit `pnpm config set` calls before `pnpm install`. This writes tokens to the user-level config (not the repo), which pnpm still respects.

```bash
pnpm config set '//<ARTIFACTORY_HOSTNAME>/artifactory/api/npm/p6m-dev-npm/:_auth' "$ARTIFACTORY_TOKEN"
pnpm config set '//<ARTIFACTORY_HOSTNAME>/artifactory/api/npm/<ORG>-npm/:_auth' "$ARTIFACTORY_TOKEN"
pnpm install
```

Also added pnpm version logging to the step summary for easier debugging going forward.

Ref: https://pnpm.io/npmrc#environment-variables-in-auth-settings
<img width="1836" height="1502" alt="Screenshot 2026-06-16 at 8 57 16 AM" src="https://github.com/user-attachments/assets/362fc6ca-2d8e-42c1-adf2-f4f1a804b154" />
Ref: https://github.com/ybor-playground/front-end-apps/actions/runs/27620058057/job/81667028861
`Install dependencies` succeeded despite the warnings about the project-level `.npmrc`